### PR TITLE
[#16] Create ~/.local/bin during install if it does not exist

### DIFF
--- a/install
+++ b/install
@@ -7,4 +7,4 @@ chmod +x hs-init.hs
 
 [ -d "$LOCAL_BIN" ] || mkdir -p "$LOCAL_BIN"
 
-mv hs-init.hs ~/.local/bin/hs-init
+mv hs-init.hs $LOCAL_BIN/hs-init

--- a/install
+++ b/install
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+LOCAL_BIN=~/.local/bin
+
 wget https://raw.githubusercontent.com/vrom911/hs-init/master/hs-init.hs
 chmod +x hs-init.hs
+
+[ -d "$LOCAL_BIN" ] || mkdir -p "$LOCAL_BIN"
+
 mv hs-init.hs ~/.local/bin/hs-init


### PR DESCRIPTION
This just adds a quick check for the existence of `~/.local/bin` during installation and creates it if necessary.