### PR TITLE
[#17] Address shellcheck warnings

### DIFF
--- a/install
+++ b/install
@@ -34,7 +34,7 @@ read_default() {
   local prompt="$1"
   local dest="$2"
 
-  IFS= read -p "$prompt" $dest <&2
+  IFS= read -r -p "$prompt" "$dest" <&2
 }
 
 # Prompt for and set default settings values in `hs-init.hs`. Any


### PR DESCRIPTION
This updates the `read_default` function in the install script to address shellcheck warnings. Namely, passing the `-r` option to `read` and double-quoting the `$dest` variable.