### PR TITLE
[#22] Get year automatically

### DIFF
--- a/hs-init.hs
+++ b/hs-init.hs
@@ -10,6 +10,7 @@
   --package optparse-applicative
   --package text
   --package neat-interpolation
+  --package time
 -}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}


### PR DESCRIPTION
I see there was already a pull request for this issue, but it appears to have some problems so I thought I would submit my own solution.

The year string was added to the ProjectData data type and as a parameter to the customizeLicense  function as it can no longer be a globally available constant.

I am fairly new to haskell, let me know if there is anything that should be improved before merge.