### PR TITLE
[#45] Add AppVeyor to hs-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.3
+=====
+
+* [#45](https://github.com/vrom911/hs-init/issues/45):
+  Support AppVeyor CI for created projects.
+
 1.0.2
 =====
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # hs-init
 
 [![Build status](https://secure.travis-ci.org/vrom911/hs-init.svg)](http://travis-ci.org/vrom911/hs-init)
+[![Windows build status](https://ci.appveyor.com/api/projects/status/github/vrom911/hs-init?branch=master&svg=true)](https://ci.appveyor.com/project/vrom911/hs-init)
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/vrom911/hs-init/blob/master/LICENSE)
-[![Version 1.0.2](https://img.shields.io/badge/version-v1.0.3-fabfff.svg)](https://github.com/vrom911/hs-init/blob/master/CHANGELOG.md)
+[![Version 1.0.3](https://img.shields.io/badge/version-v1.0.3-fabfff.svg)](https://github.com/vrom911/hs-init/blob/master/CHANGELOG.md)
 
 This is tool for creating completely configured production Haskell projects.
 Consider that this script is using [`Stack`](http://haskellstack.org) for

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://secure.travis-ci.org/vrom911/hs-init.svg)](http://travis-ci.org/vrom911/hs-init)
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/vrom911/hs-init/blob/master/LICENSE)
-[![Version 1.0.2](https://img.shields.io/badge/version-v1.0.2-fabfff.svg)](https://github.com/vrom911/hs-init/blob/master/CHANGELOG.md)
+[![Version 1.0.2](https://img.shields.io/badge/version-v1.0.3-fabfff.svg)](https://github.com/vrom911/hs-init/blob/master/CHANGELOG.md)
 
 This is tool for creating completely configured production Haskell projects.
 Consider that this script is using [`Stack`](http://haskellstack.org) for
@@ -63,7 +63,8 @@ Available commands:
 
 Available command options:
   -g, --github             Github integration
-  -c, --ci                 CI integration (Travis CI)
+  -c, --travis             Travis CI integration
+  -w, --app-veyor          AppVeyor CI integration
   -s, --script             Build script
   -l, --library            Library target
   -e, --exec               Executable target
@@ -79,11 +80,11 @@ the question will be asked during the work of the script.
 For example,
 
 ```
-  hs-init newProject on -letgcsp off -b
+  hs-init newProject on -letgcspw off -b
 ```
 will create fully functional project with library, executable file, tests,
 [build script](#build-script) and create private repository on [github](https://github.com)
-integrated with `Travis-CI`, but benchmarks won't be attached to this one.
+integrated with `Travis-CI`, `AppVeyor-CI`, but benchmarks won't be attached to this one.
 
 But when calling this command
 
@@ -123,6 +124,7 @@ PROJECT_NAME
 ├── README.md
 ├── Setup.hs
 ├── stack.yaml
+├── appveyor.yml
 ├── .git
 ├── .gitignore
 └── .travis.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+build: off
+
+before_test:
+# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\stack"
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+
+test_script:
+- stack setup > nul
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
+- echo "" | stack --no-terminal script --resolver lts-10.3 hs-init.hs -- --help

--- a/hs-init.hs
+++ b/hs-init.hs
@@ -45,6 +45,7 @@ import System.Console.ANSI (Color (Blue, Green, Red, Yellow), ColorIntensity (Vi
                             SGR (Reset, SetColor, SetConsoleIntensity), setSGR)
 import System.Directory (doesPathExist, getCurrentDirectory, setCurrentDirectory)
 import System.FilePath ((</>))
+import System.IO (hSetEncoding, stdout, utf8)
 import System.Process (callCommand, readProcess, showCommandForUser)
 
 import qualified Data.Text as T
@@ -83,7 +84,9 @@ endLine = "\n"
 ----------------------------------------------------------------------------
 
 main :: IO ()
-main = execParser prsr >>= runWithOptions
+main = do
+  hSetEncoding stdout utf8
+  execParser prsr >>= runWithOptions
 
 -- | Run 'hs-init' with cli options
 runWithOptions :: InitOpts -> IO ()


### PR DESCRIPTION
Resolves #45 

I've added AppVeyor as a separate CLI flag. Maybe if `--ci` specifed we can add both Travis and AppVeyor. I'm not sure what is more convenient for users. Maybe somebody don't want to deal with Windows...

I've also performed some cosmetic changes. And added `appveyor.yml` to `hs-init`.
@vrom911 you probably need to add `hs-init` project to AppVeyor to launch builds. I don't know how `chmod +x` works on Windows and how can I launch `hs-init --help` on Windows so I just build it with `ghc` on Windows.

Here is the example of project I've created to test AppVeyor:

* https://github.com/ChShersh/appveyor-test2