### PR TITLE
Windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ tags
 # Binaries
 hs-init
 *.hsfiles
+*.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.4
+=====
+* Now works on windows systems as well
+* Add powershell install script for Windows
+
+
 1.0.3
 =====
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To start using it make sure you have next tools installed on your machine:
 * [`Stack`](http://haskellstack.org)
 * [`git`](https://git-scm.com)
 * [`hub`](https://github.com/github/hub)
+* [`curl`](https://curl.haxx.se)
 
 ### Installation
 
@@ -47,6 +48,14 @@ it doesn't exist).
 After that you can call `hs-init` with required command line options, follow
 the instructions that will appear, and a new project would be created in a subfolder
 as well as a repository under your github account.
+
+#### windows
+A PowerShell install script is available for windows users
+
+    PS > Invoke-WebRequest https://raw.githubusercontent.com/vrom911/hs-init/master/install.ps1 -Out-File hs-init_install.ps1
+    PS > powershell.exe -ExecutionPolicy ByPass .\hs-init_install.ps1
+
+The binary will be installed to %LOCALAPPDATA%\hs-init which will also be added to your path
 
 ### Usage
 

--- a/install.ps1
+++ b/install.ps1
@@ -57,8 +57,12 @@ Write-Host "Installing hs-init.exe to $TargetDir"
 $null = New-Item $TargetDir -ItemType Directory -Force
 Move-Item .\hs-init.exe "$TargetDir\hs-init.exe" -Force
 
-Write-Host "Adding $TargetDir to Path"
-[System.Environment]::SetEnvironmentVariable("Path", $env:Path + ";$env:LOCALAPPDATA\hs-init",[System.EnvironmentVariableTarget]::User)
+if($env:Path -notmatch '(^|;)' + [Regex]::Escape("$env:localappdata\hs-init") + '(;|$)'){
+    Write-Host "Adding $TargetDir to Path"
+    [System.Environment]::SetEnvironmentVariable("Path", $env:Path + ";$TargetDir",[System.EnvironmentVariableTarget]::User)
+} else {
+    Write-Host "$TargetDir already on Path"
+}
 
 Write-Host "Cleaning up Temp Dir $TempDir"
 Set-Location ..

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,67 @@
+$ErrorActionPreference = "Stop"
+
+function populate_defaults {
+    $script:DEFAULT_OWNER= Read-Host 'Default GitHub username'
+    $script:DEFAULT_NAME=Read-Host 'Default name'
+    $script:DEFAULT_EMAIL=Read-Host 'Default email address'
+}
+function set_defaults{
+    Move-Item hs-init.hs hs-init.orig.hs
+    foreach($line in Get-Content -Encoding UTF8 hs-init.orig.hs){
+        $line = $line -replace "^(defaultOwner) = ""(.*)""$","`$1 = ""$DEFAULT_OWNER"""
+        $line = $line -replace "^(defaultName) = ""(.*)""$","`$1 = ""$DEFAULT_NAME"""
+        $line = $line -replace "^(defaultEmail) = ""(.*)""$","`$1 = ""$DEFAULT_EMAIL"""
+        $line | Out-File -encoding UTF8 -Append hs-init.hs
+    }
+    Remove-Item hs-init.orig.hs
+}
+
+function install_dependencies{
+    $packages = Select-String -Pattern "--package (.*)" -Path hs-init.hs | % {($_.matches.groups[1].value)}
+    stack install $packages
+    if($LASTEXITCODE -ne 0){
+        exit 1
+    }
+}
+
+$TempDir = "_hs-init_install_" + [GUID]::NewGuid()
+$TargetDir = "$env:LOCALAPPDATA\hs-init"
+
+Write-Host "Using temporary directory $TempDir"
+
+$null = New-Item $TempDir -ItemType Directory
+Set-Location $TempDir
+
+$hsFile = "https://raw.githubusercontent.com/vrom911/hs-init/master/hs-init.hs"
+
+Write-Host "Downloading $hsFile"
+
+Invoke-Webrequest $hsFile -OutFile .\hs-init.hs
+
+populate_defaults
+
+Write-Host "modifying hs-init.hs with selected defaults"
+set_defaults
+
+Write-Host "Installing dependencies"
+install_dependencies
+
+Write-Host "compiling"
+
+stack ghc -- -O2 hs-init.hs
+if($LASTEXITCODE -ne 0){
+    exit 1
+}
+
+Write-Host "Installing hs-init.exe to $TargetDir"
+$null = New-Item $TargetDir -ItemType Directory -Force
+Move-Item .\hs-init.exe "$TargetDir\hs-init.exe" -Force
+
+Write-Host "Adding $TargetDir to Path"
+[System.Environment]::SetEnvironmentVariable("Path", $env:Path + ";$env:LOCALAPPDATA\hs-init",[System.EnvironmentVariableTarget]::User)
+
+Write-Host "Cleaning up Temp Dir $TempDir"
+Set-Location ..
+Remove-Item $TempDir -Recurse
+
+Write-Host "Installation Complete"


### PR DESCRIPTION
Crazies like me like to work on windows sometimes.  This pr introduces a few changes to help improve the windows compatibility.

- Added a powershell install script and windows install instruction to README

- Replaced unicode chatacter → in prompt as it causes problems in
standard windows terminals

- created putStrFlush to be used instead of T.putStr, ensure content is
flushed to the console and prompts are displayed in the correct order

- replaced use of "rm" with System.Directory removeFile.  Wrapped in a
function deleteFile to continue on error

- modify setScriptCommand to do nothing on windows systems

*****

These changes should provide a basic level of support for windows platforms.  There are still some outstanding issues which are not addressed by this change:

- The build script feature still only produces a bash script.  It could potentially produce a powershell script as well for windows.

- The default background for the powershell console is blue,  the prompt arrow colour is also blue here making it a bit hard to read, perhaps the colour scheme could be adjusted.

- The tool still relies on curl to be installed for some functions.  Systems are not guaranteed to have this installed (this potentially affects linux systems as well).  For now I've added it to the prerequisite listing in the README.md, but maybe this download function could be done from the haskell code without requiring an external tool.